### PR TITLE
Add Packrift Packaging Fit Lab

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ _Additional software leveraged in the final solution._
 ### Shipping and Fulfillment
 
 - [EasyPost](https://www.easypost.com) - Create labels in a few clicks and save up to 74% or use our modern Shipping API with tracking, address verification, and customs for USPS, FedEx, UPS, DHL, plus many more.
+- [Packrift Packaging Fit Lab](https://packrift.github.io/packaging-fit-lab/) - Free packaging fit and carton-selection tool for comparing item dimensions against packaging options and exporting SKU review notes.
 - [ShipEngine](https://www.shipengine.com) - Discover the new standard in multi-carrier shipping and logistics.
 - [Shippo](https://goshippo.com) - The absolute best rates from top carriers and everything you need for professional shipping in one place.
 - [ShipStation](https://www.shipstation.com) - The Multichannel Order and Delivery Management Platform With 100+ Integrations.


### PR DESCRIPTION
Adds Packrift Packaging Fit Lab to Shipping and Fulfillment.

The tool helps ecommerce and fulfillment teams compare item dimensions against packaging options and export SKU review notes.

Validation:
- Confirmed the Fit Lab URL is public.
- Ran `git diff --check`.
