### PR TITLE
Add Superhighway retail & e-commerce research agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ _Additional software leveraged in the final solution._
 - [OpenAI](https://openai.com) - AI research company providing GPT models for commerce automation and customer engagement.
 - [RivalHound](https://www.rivalhound.com) - AI ranking analysis and sentiment tracking.
 - [Rokt](https://www.rokt.com) - AI-powered ecommerce technology for transaction moments and relevant offers.
+- [Superhighway](https://superhighway.walls.sh/guides/retail-research-agent) - AI agent for researching retail categories, e-commerce channel dynamics, digital shelf position, and DTC brand intelligence using live web search.
 
 ### Affiliate
 


### PR DESCRIPTION
Adds [Superhighway](https://superhighway.walls.sh/guides/retail-research-agent) — a guide for building Python agents that research retail categories, e-commerce channel dynamics (DTC vs. marketplace), digital shelf position, and consumer brand intelligence using live web search. Pay-per-call USDC micropayments via x402 (no signup required).