### PR TITLE
Add Ecommerce ChatGPT Prompts to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ _Additional software leveraged in the final solution._
 ### AI
 
 - [Anthropic](https://www.anthropic.com) - AI safety company building Claude, powering conversational commerce and intelligent assistants.
+- [Ecommerce ChatGPT Prompts](https://www.xpay.sh/prompts/) - Free, copy-and-run ChatGPT prompt library for online stores covering product descriptions, ads, email, and SEO.
 - [Google Vertex AI](https://cloud.google.com/vertex-ai) - Unified ML platform for building and deploying AI-powered commerce experiences.
 - [Nosto](https://www.nosto.com) - AI-powered commerce experience platform for personalization and merchandising.
 - [OpenAI](https://openai.com) - AI research company providing GPT models for commerce automation and customer engagement.


### PR DESCRIPTION
Adds one entry to the **AI** section (placed alphabetically):

> [Ecommerce ChatGPT Prompts](https://www.xpay.sh/prompts/) — a free, copy-and-run ChatGPT prompt library for online stores (product descriptions, ads, email, SEO).

Matched the `[Name](url) - Description.` format used in the section. The library is free.

Disclosure: I work on xpay, which publishes this free prompts library.